### PR TITLE
修复React网页前端无法显示本地图片（png,svg图片）的问题

### DIFF
--- a/src/scenes/Landing.jsx
+++ b/src/scenes/Landing.jsx
@@ -21,7 +21,7 @@ const Landing = ({ setSelectedPage }) => {
             <img
               alt="profile"
               className="hover:filter hover:saturate-200 transition dutation-500 z-10 w-full max-w-[400px] md:max-w-[600px]"
-              src="../assets/profile-image.png"
+              src={require("../assets/profile-image.png")}
             />
           </div>
         ) : (

--- a/src/scenes/Navbar.jsx
+++ b/src/scenes/Navbar.jsx
@@ -61,7 +61,10 @@ const Navbar = ({ isTopOfPage, selectedPage, setSelectedPage }) => {
             className="rounded-full bg-red "
             onClick={() => setisMenuToggled(!isMenuToggled)}
           >
-            <img alt="menu-icon" src="../assets/menu-icon.svg" />
+            <img
+              alt="menu-icon"
+              src={require("../assets/menu-icon.svg").default}
+            />
           </button>
         )}
 
@@ -70,7 +73,10 @@ const Navbar = ({ isTopOfPage, selectedPage, setSelectedPage }) => {
           <div className="fixed right-0 bottom-0 h-full bg-blue w-[300px]">
             <div className="flex justify-end p-12">
               <button onClick={() => setisMenuToggled(!isMenuToggled)}>
-                <img alt="close-icon" src="../assets/close-icon.svg" />
+                <img
+                  alt="close-icon"
+                  src={require("../assets/close-icon.svg").default}
+                />
               </button>
             </div>
 


### PR DESCRIPTION
## 变更内容：修复React网页前端无法显示本地图片（png,svg图片）的问题
-- 在<img>标签中的src属性中，如果为svg图片，则将图片的地址前添加{require(...).default}
-- 如果为png图片，则将图片的地址前添加{require(...)}